### PR TITLE
Add data attribute for (result) count represented by a pill

### DIFF
--- a/pagefind_ui/modular/components/filterPills.js
+++ b/pagefind_ui/modular/components/filterPills.js
@@ -85,7 +85,7 @@ export class FilterPills {
 
     pillInner(val, count) {
         if (this.total) {
-            return `<span aria-label="${val}">${val} (${count})</span>`;
+            return `<span aria-label="${val}" data-pfmod-pill-count="${count}">${val} (${count})</span>`;
         } else {
             return `<span aria-label="${val}">${val}</span>`;
         }


### PR DESCRIPTION
Makes it possible to hide empty filters using CSS:
```css
.pagefind-modular-filter-pill:has(span[data-pfmod-pill-count="0"]) {
  display: none
}
```

Would also allow to create a Tag cloud like representation of filters.