### PR TITLE
i18n(de): Fix grammar error and follow proper orthographic rules

### DIFF
--- a/pagefind_ui/translations/de.json
+++ b/pagefind_ui/translations/de.json
@@ -13,6 +13,6 @@
         "one_result": "[COUNT] Ergebnis für [SEARCH_TERM]",
         "alt_search": "Keine Ergebnisse für [SEARCH_TERM]. Stattdessen werden Ergebnisse für [DIFFERENT_TERM] angezeigt",
         "search_suggestion": "Keine Ergebnisse für [SEARCH_TERM]. Versuchen Sie eine der folgenden Suchen:",
-        "searching": "Suche für [SEARCH_TERM]"
+        "searching": "Suche nach [SEARCH_TERM] …"
     }
 }


### PR DESCRIPTION
#### Description

- Fix grammar error regarding about a preposition
- Add missing ellipsis (present in English) and add a narrow NBSP in front (looks nicer in my opinion)[^1]

[^1]: Duden recommends a space before the ellipsis. A non‐breaking space prevents a line break in between. A narrow non‐breaking space is thinner than a standard non‐breaking space, hence I used it in the PR. Citation: https://www.duden.de/sprachwissen/rechtschreibregeln/auslassungspunkte (German)