### PR TITLE
feat: segment Korean (ko) text with lindera ko-dic

### DIFF
--- a/pagefind/Cargo.toml
+++ b/pagefind/Cargo.toml
@@ -57,6 +57,7 @@ convert_case = "0.11.0"
 charabia = { version = "0.9.3", optional = true, default-features = false, features = [
     "chinese",
     "japanese",
+    "korean",
     "thai",
 ] }
 unicode-segmentation = "1.10.1"

--- a/pagefind/src/fossick/mod.rs
+++ b/pagefind/src/fossick/mod.rs
@@ -367,7 +367,8 @@ impl Fossicker {
         let segment_chunks = data.digest.split_whitespace();
 
         #[cfg(feature = "extended")]
-        let should_segment = matches!(data.language.split('-').next().unwrap(), "zh" | "ja" | "th");
+        let should_segment =
+            matches!(data.language.split('-').next().unwrap(), "zh" | "ja" | "th" | "ko");
 
         #[cfg(feature = "extended")]
         let coarse_segments = segment_chunks.map(|seg| {

--- a/pagefind_web_js/lib/coupled_search.ts
+++ b/pagefind_web_js/lib/coupled_search.ts
@@ -24,7 +24,7 @@ const isBrowser = () =>
 const needsWordSegmentation = (lang: string | null): boolean => {
   if (!lang) return false;
   const primaryLang = lang.split("-")[0].toLowerCase();
-  return ["zh", "ja", "th"].includes(primaryLang);
+  return ["zh", "ja", "th", "ko"].includes(primaryLang);
 };
 
 export class PagefindInstance {


### PR DESCRIPTION
Korean was tokenized on whitespace only (should_segment covered just zh/ja/th), so an 어절 such as 서울은 was indexed as a single token and a search for 서울 would miss it.
Charabia already ships a Korean feature (lindera ko-dic)[^1] and browsers expose Intl.Segmenter('ko'), so enable it on both the index side and the query side, matching how ja/zh/th work.

[^1]: #177