### PR TITLE
chore: fix pagefind_stem license field

### DIFF
--- a/pagefind_stem/Cargo.toml
+++ b/pagefind_stem/Cargo.toml
@@ -5,7 +5,7 @@ version = "1.0.0"
 # and I don't want to have to edit snowball's rust files
 edition = "2015"
 description = "Snowball stemming algorithms repackaged for Rust, with languages behind feature flags."
-license = "MIT"
+license = "MIT AND BSD-3-Clause"
 
 [dependencies]
 


### PR DESCRIPTION
The Rust source code for pagefind_stem already includes a header comment with both the MIT and BSD-3-Clause license headers that cover the different parts of the code. Cargo [supports SPDX license expressions](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields) so we can indicate both licenses correctly in the crate metadata.