### PR TITLE
Support explicit sub-result titles

### DIFF
--- a/docs/content/docs/sub-results.md
+++ b/docs/content/docs/sub-results.md
@@ -28,7 +28,24 @@ The `<pagefind-searchbox>` component hides sub results by default. To show them,
 ```
 {{< /diffcode >}}
 
-Sub results split the page on headings (`h1` → `h6`) that have `id` attributes that can be linked to. Sections with the most hits will be given priority.
+Sub results split the page on headings (`h1` → `h6`) that have `id` attributes that can be linked to, or elements with both an `id` and a `data-pagefind-title` attribute. Sections with the most hits will be given priority.
+
+## Defining a sub result explicitly
+
+If an element other than a heading should define a sub result, give it an `id` and a `data-pagefind-title` attribute:
+
+{{< diffcode >}}
+```html
+<section
+    id="installation"
+    data-pagefind-title="Installation">
+    <h2>Installation</h2>
+    <p>Install the package with ...</p>
+</section>
+```
+{{< /diffcode >}}
+
+The attribute value is used as the sub-result title, and the element's `id` is used as the URL fragment. This is useful when an existing HTML structure places the linkable ID on a container around its heading.
 
 ## Retrieving sub results using the JavaScript API
 
@@ -72,7 +89,7 @@ Which will return an object with the following structure:
 ```
 {{< /diffcode >}}
 
-These results are split on headings (`h1` → `h6`) that have `id` attributes that can be linked to.
+These results are split on headings (`h1` → `h6`) that have `id` attributes that can be linked to, and explicitly titled elements marked with `data-pagefind-title`.
 
 If there are matches for the search term on the page _before_ the first heading with an ID, the first sub result in this list will be the URL and title of the page itself, and will not contain an `anchor` key. All other sub results will have a URL linking directly to that heading, and will have an `anchor` key with details about the element.
 

--- a/pagefind/integration_tests/anchors/background.toolproof.yml
+++ b/pagefind/integration_tests/anchors/background.toolproof.yml
@@ -45,6 +45,11 @@ steps:
 
           <div id="double_div">Divs containing <div>💀 he he he 💀</div> divs should only take from the top level</div>
           <p>Some text nested under the divs</p>
+
+          <section id="explicit_section" data-pagefind-title="Installation &amp; Usage">
+              <h2>Installation and usage</h2>
+              <p>Platypus content nested under an explicitly titled section</p>
+          </section>
       </div></body></html>
   - step: I have a "public/repr/index.html" file with the content {html}
     html: |-

--- a/pagefind/integration_tests/anchors/pagefind-returns-subresults-for-explicitly-titled-elements.toolproof.yml
+++ b/pagefind/integration_tests/anchors/pagefind-returns-subresults-for-explicitly-titled-elements.toolproof.yml
@@ -1,0 +1,22 @@
+name: Anchors > Pagefind returns subresults for explicitly titled elements
+steps:
+  - ref: ./background.toolproof.yml
+  - step: In my browser, I evaluate {js}
+    js: |-
+      let pagefind = await import("/pagefind/pagefind.js");
+
+      let search = await pagefind.search("platypus");
+      let searchdata = await search.results[0].data();
+      document.querySelector('[data-search]').innerHTML = `
+          <ul>
+              ${searchdata.sub_results.map(r => `<li>${r.url}: ${r.title} / '${r.excerpt}'</li>`).join('')}
+          </ul>
+      `;
+  - step: In my browser, the console should be empty
+  - step: In my browser, I evaluate {js}
+    js: >-
+      let val = await toolproof.querySelector("[data-search]>ul>li");
+
+      toolproof.assert_eq(val.innerHTML, `/dog/#explicit_section: Installation &amp;
+      Usage / 'Installation and usage. <mark>Platypus</mark> content nested
+      under an explicitly titled section.'`);

--- a/pagefind/src/fossick/mod.rs
+++ b/pagefind/src/fossick/mod.rs
@@ -321,15 +321,7 @@ impl Fossicker {
                     filters: data.filters,
                     meta: data.meta,
                     word_count,
-                    anchors: anchors
-                        .into_iter()
-                        .map(|(element, id, text, location)| PageAnchorData {
-                            element,
-                            id,
-                            location,
-                            text,
-                        })
-                        .collect(),
+                    anchors,
                 },
             },
             word_data,
@@ -344,7 +336,7 @@ impl Fossicker {
     ) -> (
         String,
         HashMap<String, Vec<FossickedWord>>,
-        Vec<(String, String, String, u32)>,
+        Vec<PageAnchorData>,
         usize,
     ) {
         let mut map: HashMap<String, Vec<FossickedWord>> = HashMap::new();
@@ -410,14 +402,16 @@ impl Fossicker {
                             .get(anchor_id)
                             .map(|t| normalize_content(t))
                             .unwrap_or_default();
+                        let title = data.anchor_titles.get(anchor_id).cloned();
 
                         if let Some((_, element_id)) = anchor_id.split_once(':') {
-                            anchors.push((
-                                element_name.to_string(),
-                                element_id.to_string(),
-                                normalize_content(&element_text),
-                                total_word_index as u32,
-                            ));
+                            anchors.push(PageAnchorData {
+                                element: element_name.to_string(),
+                                id: element_id.to_string(),
+                                text: normalize_content(&element_text),
+                                location: total_word_index as u32,
+                                title,
+                            });
                         }
                     }
                     return;

--- a/pagefind/src/fossick/parser.rs
+++ b/pagefind/src/fossick/parser.rs
@@ -58,6 +58,7 @@ struct DomParserData {
     meta: BTreeMap<String, String>,
     default_meta: BTreeMap<String, String>,
     anchor_content: BTreeMap<String, String>,
+    anchor_titles: BTreeMap<String, String>,
     language: Option<String>,
     has_html_element: bool,
     has_old_bundle_reference: bool,
@@ -109,6 +110,7 @@ pub struct DomParserResult {
     pub sort: BTreeMap<String, String>,
     pub meta: BTreeMap<String, String>,
     pub anchor_content: BTreeMap<String, String>,
+    pub anchor_titles: BTreeMap<String, String>,
     pub has_custom_body: bool,
     pub force_inclusion: bool, // Include this page even if there is no body
     pub has_html_element: bool,
@@ -166,6 +168,7 @@ impl<'a> DomParser<'a> {
                         let weight = el.get_attribute("data-pagefind-weight").map(|attr| attr.to_string());
                         let filter = el.get_attribute("data-pagefind-filter").map(|attr| parse_attr_string(attr, el));
                         let element_id = el.get_attribute("id").map(|e| ALL_SPACES.replace_all(&e, "").to_string());
+                        let pagefind_title = el.get_attribute("data-pagefind-title").map(|title| normalize_content(&title)).filter(|title| !title.is_empty());
                         let meta = el.get_attribute("data-pagefind-meta").map(|attr| parse_attr_string(attr, el));
                         let default_meta = el.get_attribute("data-pagefind-default-meta").map(|attr| parse_attr_string(attr, el));
                         let sort = el.get_attribute("data-pagefind-sort").map(|attr| parse_attr_string(attr, el));
@@ -194,6 +197,10 @@ impl<'a> DomParser<'a> {
                                     anchor_counter += 1;
                                 }
                             }
+                        }
+
+                        if let (Some(anchor_id), Some(title)) = (&anchor_id, pagefind_title) {
+                            data.borrow_mut().anchor_titles.insert(anchor_id.clone(), title);
                         }
 
                         if status != NodeStatus::Excluded {
@@ -623,6 +630,7 @@ impl<'a> DomParser<'a> {
             sort: data.sort,
             meta: data.default_meta,
             anchor_content: data.anchor_content,
+            anchor_titles: data.anchor_titles,
             has_custom_body: node.status == NodeStatus::ParentOfBody,
             force_inclusion: false,
             has_html_element: data.has_html_element,
@@ -752,6 +760,20 @@ mod tests {
             data.digest,
             "Sentence one. ___PAGEFIND_ANCHOR___br:0:break ___PAGEFIND_ANCHOR___p:1:pid Sentence two."
         )
+    }
+
+    #[test]
+    fn explicit_anchor_titles() {
+        let data = test_parse(vec![
+            "<section id='usage' data-pagefind-title='Installation &amp; Usage'>",
+            "<h2>Installation and usage</h2>",
+            "</section>",
+        ]);
+
+        assert_eq!(
+            data.anchor_titles.get("0:usage"),
+            Some(&"Installation & Usage".to_owned())
+        );
     }
 
     #[test]

--- a/pagefind/src/fragments/mod.rs
+++ b/pagefind/src/fragments/mod.rs
@@ -7,6 +7,8 @@ pub struct PageAnchorData {
     pub element: String,
     pub id: String,
     pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     pub location: u32,
 }
 

--- a/pagefind/src/service/api.rs
+++ b/pagefind/src/service/api.rs
@@ -147,6 +147,7 @@ impl PagefindIndex {
             sort: sort.unwrap_or_default(),
             meta: meta.unwrap_or_default(),
             anchor_content: BTreeMap::new(),
+            anchor_titles: BTreeMap::new(),
             has_custom_body: false,
             force_inclusion: true,
             has_html_element: true,

--- a/pagefind_web_js/lib/sub_results.ts
+++ b/pagefind_web_js/lib/sub_results.ts
@@ -8,7 +8,9 @@ export const calculate_sub_results = (
 
   const anchors = fragment.anchors
     .filter(
-      (a) => /h\d/i.test(a.element) && a.text?.length && /\S/.test(a.text)
+      (a) =>
+        (a.title?.length && /\S/.test(a.title)) ||
+        (/h\d/i.test(a.element) && a.text?.length && /\S/.test(a.text))
     )
     .sort((a, b) => a.location - b.location);
   const results: PagefindSubResult[] = [];
@@ -88,7 +90,7 @@ export const calculate_sub_results = (
 
       current_anchor_position = next_anchor.location;
       current_anchor = {
-        title: next_anchor.text!,
+        title: next_anchor.title || next_anchor.text!,
         url: anchored_url,
         anchor: next_anchor,
         weighted_locations: [word],

--- a/pagefind_web_js/tests/sub_results.test.ts
+++ b/pagefind_web_js/tests/sub_results.test.ts
@@ -1,0 +1,27 @@
+import test from "ava";
+import type * as external from "../types/index";
+
+import { calculate_sub_results } from "../lib/sub_results";
+
+test("explicit anchor titles create sub results", (t) => {
+  const fragment = {
+    url: "/guide/",
+    raw_content: "Install the package",
+    meta: { title: "Guide" },
+    anchors: [
+      {
+        element: "section",
+        id: "installation",
+        title: "Installation",
+        location: 0,
+      },
+    ],
+    weighted_locations: [{ weight: 1, balanced_score: 1, location: 1 }],
+  } as PagefindSearchFragment;
+
+  const results = calculate_sub_results(fragment, 30);
+
+  t.is(results.length, 1);
+  t.is(results[0].title, "Installation");
+  t.is(results[0].url, "/guide/#installation");
+});

--- a/pagefind_web_js/types/index.d.ts
+++ b/pagefind_web_js/types/index.d.ts
@@ -413,6 +413,8 @@ declare global {
     element: string;
     /** The raw id="..." attribute contents of the element */
     id: string;
+    /** An explicit sub-result title supplied by a data-pagefind-title attribute */
+    title?: string;
     /**
      * The text content of this element.
      *


### PR DESCRIPTION
## Summary

- support `data-pagefind-title` on any indexed element with an `id`
- preserve the explicit title on the existing anchor record
- treat explicitly titled anchors as sub-result boundaries
- document the attribute and cover it with parser, JavaScript, and integration tests

```html
<section id="installation" data-pagefind-title="Installation">
  <h2>Installation</h2>
  ...
</section>
```

This provides an explicit solution for generated documentation where the linkable ID belongs to a section surrounding its heading. Existing heading-based sub-results are unchanged, and the additional anchor field is omitted unless the attribute is present.

Closes #818.

## Testing

- `cargo test --release --lib` — 33 passed
- `pnpm exec ava tests/sub_results.test.ts` — 1 passed
- `pnpm run build-coupled`
