### PR TITLE
fix(component-ui): ignore keystrokes belonging to an IME composition

### DIFF
--- a/pagefind/integration_tests/web_components/modal-ime-composition.toolproof.yml
+++ b/pagefind/integration_tests/web_components/modal-ime-composition.toolproof.yml
@@ -1,0 +1,63 @@
+name: Web Components Tests > Escape during an IME composition does not close the modal or clear the query
+steps:
+  - step: I have the environment variable "PAGEFIND_SITE" set to "public"
+  - step: I have a "public/index.html" file with the content {html}
+    html: |-
+      <!DOCTYPE html><html lang="en"><head>
+      <link href="/pagefind/pagefind-component-ui.css" rel="stylesheet">
+      </head><body>
+      <pagefind-config preload></pagefind-config>
+      <pagefind-modal-trigger></pagefind-modal-trigger>
+      <pagefind-modal>
+        <pagefind-modal-header>
+          <pagefind-input></pagefind-input>
+        </pagefind-modal-header>
+        <pagefind-modal-body>
+          <pagefind-summary></pagefind-summary>
+          <pagefind-results></pagefind-results>
+        </pagefind-modal-body>
+        <pagefind-modal-footer></pagefind-modal-footer>
+      </pagefind-modal>
+      <script src="/pagefind/pagefind-component-ui.js" type="module"></script>
+      </body></html>
+  - step: I have a "public/cat/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html lang="en"><head></head><body><h1>world</h1></body></html>
+  - macro: I run Pagefind
+  - step: stdout should contain "Running Pagefind"
+  - step: The file "public/pagefind/pagefind.js" should not be empty
+  - step: I serve the directory "public"
+  - step: In my browser, I load "/"
+  - step: In my browser, I click the selector "pagefind-modal-trigger button"
+  - step: In my browser, I evaluate {js}
+    js: |-
+      let dialog = await toolproof.querySelector("pagefind-modal dialog");
+      await toolproof.waitFor(() => dialog.open === true);
+  - step: In my browser, I type "world"
+  - step: In my browser, I evaluate {js}
+    js: |-
+      let input = await toolproof.querySelector("pagefind-modal input");
+      await toolproof.waitFor(() => input.value === "world", "Input should have query text");
+  # Escape during a composition cancels the conversion. Closing the modal, or
+  # clearing the query, would discard everything typed so far.
+  - step: In my browser, I evaluate {js}
+    js: |-
+      let dialog = await toolproof.querySelector("pagefind-modal dialog");
+      let input = await toolproof.querySelector("pagefind-modal input");
+      input.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
+      input.dispatchEvent(new KeyboardEvent("keydown", {
+        key: "Escape", bubbles: true, cancelable: true, isComposing: true,
+      }));
+      toolproof.assert(dialog.open === true, "Modal should stay open during a composition");
+      toolproof.assert(input.value === "world", "Query should not be cleared during a composition");
+  # Composition over: Escape must close the modal exactly as before.
+  - step: In my browser, I evaluate {js}
+    js: |-
+      let input = await toolproof.querySelector("pagefind-modal input");
+      input.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true, data: "world" }));
+      input.dispatchEvent(new KeyboardEvent("keyup", { key: "Escape", bubbles: true }));
+  - step: In my browser, I press the "Escape" key
+  - step: In my browser, I evaluate {js}
+    js: |-
+      let dialog = await toolproof.querySelector("pagefind-modal dialog");
+      await toolproof.waitFor(() => dialog.open === false, "Modal should close on Escape once composition has ended");

--- a/pagefind/integration_tests/web_components/searchbox-ime-composition.toolproof.yml
+++ b/pagefind/integration_tests/web_components/searchbox-ime-composition.toolproof.yml
@@ -1,0 +1,84 @@
+name: Web Components Tests > Searchbox ignores keys belonging to an IME composition
+steps:
+  - step: I have the environment variable "PAGEFIND_SITE" set to "public"
+  - step: I have a "public/index.html" file with the content {html}
+    html: |-
+      <!DOCTYPE html><html lang="en"><head>
+      <link href="/pagefind/pagefind-component-ui.css" rel="stylesheet">
+      </head><body>
+      <pagefind-config preload></pagefind-config>
+      <pagefind-searchbox></pagefind-searchbox>
+      <script src="/pagefind/pagefind-component-ui.js" type="module"></script>
+      </body></html>
+  - step: I have a "public/one/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html lang="en"><head></head><body><h1>First Result</h1></body></html>
+  - step: I have a "public/two/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html lang="en"><head></head><body><h1>Second Result</h1></body></html>
+  - macro: I run Pagefind
+  - step: stdout should contain "Running Pagefind"
+  - step: The file "public/pagefind/pagefind.js" should not be empty
+  - step: I serve the directory "public"
+  - step: In my browser, I load "/"
+  - step: In my browser, I click the selector "pagefind-searchbox input"
+  - step: In my browser, I type "Result"
+  - step: In my browser, I evaluate {js}
+    js: |-
+      let box = await toolproof.querySelector("pagefind-searchbox");
+      await toolproof.waitFor(() => box.querySelectorAll('[role="option"]').length > 0);
+  # An IME is now composing: the keys below are the user choosing characters,
+  # not the user choosing a result.
+  - step: In my browser, I evaluate {js}
+    js: |-
+      let box = await toolproof.querySelector("pagefind-searchbox");
+      let input = box.querySelector("input");
+      window.__path = window.location.pathname;
+      window.__offset = box.activeOptionOffset;
+      input.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
+      input.dispatchEvent(new KeyboardEvent("keydown", {
+        key: "ArrowDown", bubbles: true, cancelable: true, isComposing: true,
+      }));
+      toolproof.assert(
+        box.activeOptionOffset === window.__offset,
+        "Walking IME candidates should not move the result selection",
+      );
+  - step: In my browser, I evaluate {js}
+    js: |-
+      let box = await toolproof.querySelector("pagefind-searchbox");
+      let input = box.querySelector("input");
+      input.dispatchEvent(new KeyboardEvent("keydown", {
+        key: "Enter", bubbles: true, cancelable: true, isComposing: true,
+      }));
+      toolproof.assert(
+        window.location.pathname === window.__path,
+        "Committing an IME conversion should not navigate to a result",
+      );
+  # WebKit fires compositionend *before* the keydown that ended the
+  # composition, so that Enter arrives with isComposing already false.
+  - step: In my browser, I evaluate {js}
+    js: |-
+      let box = await toolproof.querySelector("pagefind-searchbox");
+      let input = box.querySelector("input");
+      input.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true, data: "Result" }));
+      input.dispatchEvent(new KeyboardEvent("keydown", {
+        key: "Enter", bubbles: true, cancelable: true, isComposing: false,
+      }));
+      toolproof.assert(
+        window.location.pathname === window.__path,
+        "An Enter arriving right after compositionend should not navigate",
+      );
+  # Composition is over, so ordinary keyboard navigation must work as before.
+  - step: In my browser, I evaluate {js}
+    js: |-
+      let box = await toolproof.querySelector("pagefind-searchbox");
+      let input = box.querySelector("input");
+      input.dispatchEvent(new KeyboardEvent("keyup", { key: "Enter", bubbles: true }));
+      let before = box.activeOptionOffset;
+      input.dispatchEvent(new KeyboardEvent("keydown", {
+        key: "ArrowDown", bubbles: true, cancelable: true,
+      }));
+      toolproof.assert(
+        box.activeOptionOffset !== before,
+        "ArrowDown outside a composition should still move the selection",
+      );

--- a/pagefind/integration_tests/web_components/searchbox-ime-composition.toolproof.yml
+++ b/pagefind/integration_tests/web_components/searchbox-ime-composition.toolproof.yml
@@ -23,33 +23,52 @@ steps:
   - step: In my browser, I load "/"
   - step: In my browser, I click the selector "pagefind-searchbox input"
   - step: In my browser, I type "Result"
+  # Wait for both results to load, not just for options to exist: moving the
+  # selection onto an unloaded result queues a load instead of moving.
   - step: In my browser, I evaluate {js}
     js: |-
-      let box = await toolproof.querySelector("pagefind-searchbox");
-      await toolproof.waitFor(() => box.querySelectorAll('[role="option"]').length > 0);
+      await toolproof.waitFor(() => document.querySelectorAll("a.pf-searchbox-result").length === 2, "Both results should load");
+      await toolproof.waitFor(() => document.querySelector("a.pf-searchbox-result[data-pf-selected]") !== null, "First result should be selected");
   # An IME is now composing: the keys below are the user choosing characters,
-  # not the user choosing a result.
+  # not the user choosing a result. `defaultPrevented` is the direct reading of
+  # whether the searchbox acted, since every branch it would take calls
+  # preventDefault() first.
   - step: In my browser, I evaluate {js}
     js: |-
       let box = await toolproof.querySelector("pagefind-searchbox");
       let input = box.querySelector("input");
       window.__path = window.location.pathname;
-      window.__offset = box.activeOptionOffset;
+      window.__index = box.activeIndex;
       input.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
-      input.dispatchEvent(new KeyboardEvent("keydown", {
+      let arrow = new KeyboardEvent("keydown", {
         key: "ArrowDown", bubbles: true, cancelable: true, isComposing: true,
-      }));
+      });
+      input.dispatchEvent(arrow);
       toolproof.assert(
-        box.activeOptionOffset === window.__offset,
-        "Walking IME candidates should not move the result selection",
+        !arrow.defaultPrevented,
+        "Walking IME candidates should not be taken by the searchbox",
+      );
+      toolproof.assert(
+        box.activeIndex === window.__index,
+        `Walking IME candidates should not move the result selection, moved to ${box.activeIndex}`,
       );
   - step: In my browser, I evaluate {js}
     js: |-
       let box = await toolproof.querySelector("pagefind-searchbox");
       let input = box.querySelector("input");
-      input.dispatchEvent(new KeyboardEvent("keydown", {
+      let container = await toolproof.querySelector(".pf-searchbox");
+      let enter = new KeyboardEvent("keydown", {
         key: "Enter", bubbles: true, cancelable: true, isComposing: true,
-      }));
+      });
+      input.dispatchEvent(enter);
+      toolproof.assert(
+        !enter.defaultPrevented,
+        "Committing an IME conversion should not be taken by the searchbox",
+      );
+      toolproof.assert(
+        container.classList.contains("open"),
+        "Committing an IME conversion should not activate a result",
+      );
       toolproof.assert(
         window.location.pathname === window.__path,
         "Committing an IME conversion should not navigate to a result",
@@ -60,25 +79,35 @@ steps:
     js: |-
       let box = await toolproof.querySelector("pagefind-searchbox");
       let input = box.querySelector("input");
+      let container = await toolproof.querySelector(".pf-searchbox");
       input.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true, data: "Result" }));
-      input.dispatchEvent(new KeyboardEvent("keydown", {
+      let enter = new KeyboardEvent("keydown", {
         key: "Enter", bubbles: true, cancelable: true, isComposing: false,
-      }));
+      });
+      input.dispatchEvent(enter);
+      toolproof.assert(
+        !enter.defaultPrevented,
+        "An Enter arriving right after compositionend should not be taken by the searchbox",
+      );
+      toolproof.assert(
+        container.classList.contains("open"),
+        "An Enter arriving right after compositionend should not activate a result",
+      );
       toolproof.assert(
         window.location.pathname === window.__path,
         "An Enter arriving right after compositionend should not navigate",
       );
   # Composition is over, so ordinary keyboard navigation must work as before.
+  # The keyup is what a real keystroke would deliver, and it closes the window
+  # held open for WebKit's event ordering.
   - step: In my browser, I evaluate {js}
     js: |-
-      let box = await toolproof.querySelector("pagefind-searchbox");
-      let input = box.querySelector("input");
+      let input = await toolproof.querySelector("pagefind-searchbox input");
       input.dispatchEvent(new KeyboardEvent("keyup", { key: "Enter", bubbles: true }));
-      let before = box.activeOptionOffset;
-      input.dispatchEvent(new KeyboardEvent("keydown", {
-        key: "ArrowDown", bubbles: true, cancelable: true,
-      }));
-      toolproof.assert(
-        box.activeOptionOffset !== before,
+  - step: In my browser, I press the "ArrowDown" key
+  - step: In my browser, I evaluate {js}
+    js: |-
+      await toolproof.waitFor(
+        () => document.querySelectorAll("a.pf-searchbox-result")[1]?.hasAttribute("data-pf-selected"),
         "ArrowDown outside a composition should still move the selection",
       );

--- a/pagefind_ui/component/components/pagefind-input.ts
+++ b/pagefind_ui/component/components/pagefind-input.ts
@@ -1,5 +1,6 @@
 import { PagefindElement } from "./base-element";
 import { Instance } from "../core/instance";
+import { trackComposition } from "../core/composition";
 import type { PagefindError } from "../types";
 
 const asyncSleep = (ms = 100): Promise<void> =>
@@ -124,7 +125,15 @@ export class PagefindInput extends PagefindElement {
       }
     });
 
+    const isComposingKey = trackComposition(this.inputEl);
+
     this.inputEl.addEventListener("keydown", (e) => {
+      // Escape cancels an in-progress IME conversion; clearing the query on it
+      // would throw away everything the user had typed so far.
+      if (isComposingKey(e)) {
+        return;
+      }
+
       if (e.key === "Escape") {
         ++this.searchID;
         if (this.inputEl) this.inputEl.value = "";

--- a/pagefind_ui/component/components/pagefind-modal.ts
+++ b/pagefind_ui/component/components/pagefind-modal.ts
@@ -1,5 +1,6 @@
 import { PagefindElement } from "./base-element";
 import { Instance, PagefindComponent } from "../core/instance";
+import { trackComposition } from "../core/composition";
 
 interface ModalTrigger extends PagefindComponent {
   buttonEl?: HTMLButtonElement;
@@ -90,12 +91,20 @@ export class PagefindModal extends PagefindElement {
     };
     this.dialogEl.addEventListener("close", this._closeHandler);
 
+    const isComposingKey = trackComposition(this.dialogEl);
+
     this.dialogEl.addEventListener(
       "keydown",
       (e) => {
         if (e.key === "Escape") {
+          // Still cancelled, so the dialog's own close-watcher does not fire,
+          // but Escape during an IME composition cancels the conversion rather
+          // than dismissing the whole modal the user is typing into.
           e.preventDefault();
           e.stopPropagation();
+          if (isComposingKey(e)) {
+            return;
+          }
           this.close();
         }
       },

--- a/pagefind_ui/component/components/pagefind-searchbox.ts
+++ b/pagefind_ui/component/components/pagefind-searchbox.ts
@@ -1,5 +1,6 @@
 import { PagefindElement } from "./base-element";
 import { Instance } from "../core/instance";
+import { trackComposition } from "../core/composition";
 import { compile, type Template } from "adequate-little-templates";
 import {
   type KeyBinding,
@@ -500,7 +501,16 @@ export class PagefindSearchbox extends PagefindElement {
       this.instance?.triggerSearch(value);
     });
 
+    const isComposingKey = trackComposition(this.inputEl);
+
     this.inputEl.addEventListener("keydown", (e) => {
+      // Keys that drive an IME belong to the IME. Acting on them navigates the
+      // user to a result, or moves the selection under them, while they are
+      // still choosing characters.
+      if (isComposingKey(e)) {
+        return;
+      }
+
       switch (e.key) {
         case "ArrowDown":
           e.preventDefault();

--- a/pagefind_ui/component/core/composition.ts
+++ b/pagefind_ui/component/core/composition.ts
@@ -1,0 +1,61 @@
+const COMPOSITION_TAIL_MS = 50;
+
+/**
+ * Track IME composition on an input, and report whether a given keydown
+ * belongs to that composition.
+ *
+ * Typing Japanese, Chinese or Korean routes keystrokes through an IME: typing
+ * `toukyou` produces the reading `とうきょう`, Space offers candidates, arrows
+ * walk them, and Enter commits `東京`. Those keys reach the page as well, so a
+ * component that acts on Enter or the arrow keys will act while the user is
+ * still mid-word.
+ *
+ * `KeyboardEvent.isComposing` covers most of this, but not all of it, so two
+ * further signals are tracked here:
+ *
+ * - WebKit fires `compositionend` *before* the keydown that ended the
+ *   composition, leaving `isComposing` already false on the Enter that commits
+ *   a conversion. A keydown arriving immediately after `compositionend` is
+ *   therefore still treated as part of it, and that window is closed on the
+ *   next keyup — Chromium and Gecko order the same three events keydown →
+ *   compositionend → keyup, so their window shuts before the user's next
+ *   keystroke.
+ * - `compositionstart` / `compositionend` also cover engines that leave
+ *   `isComposing` unset on a key that is part of a composition, without
+ *   reaching for the deprecated `keyCode === 229` test.
+ *
+ * Composition events bubble, so this can be bound either to the input itself
+ * or to a container above it. Either way the listeners are released with the
+ * element they are bound to.
+ */
+export function trackComposition(
+  element: HTMLElement,
+): (e: KeyboardEvent) => boolean {
+  let composing = false;
+  let endedAt = Number.NEGATIVE_INFINITY;
+
+  element.addEventListener("compositionstart", () => {
+    composing = true;
+  });
+
+  element.addEventListener("compositionend", () => {
+    composing = false;
+    endedAt = performance.now();
+  });
+
+  element.addEventListener("keyup", () => {
+    endedAt = Number.NEGATIVE_INFINITY;
+  });
+
+  // A composition abandoned by leaving the field never gets its
+  // `compositionend`, and a stuck flag would swallow keys indefinitely.
+  // `focusout` rather than `blur` so this also holds when tracking a container.
+  element.addEventListener("focusout", () => {
+    composing = false;
+  });
+
+  return (e: KeyboardEvent) =>
+    e.isComposing ||
+    composing ||
+    performance.now() - endedAt < COMPOSITION_TAIL_MS;
+}


### PR DESCRIPTION
Fixes #1283.

Typing Japanese, Chinese or Korean routes keystrokes through an IME. Typing
`toukyou` produces the reading `とうきょう`, Space offers candidates, arrows walk
them, and Enter commits `東京`. Those keys reach the page as well, and the
component UI acted on them while the user was still mid-word.

## What was broken

**`pagefind-searchbox`** — `activeIndex` is `0` as soon as results render, so the
Enter that commits a conversion took the `activateCurrentSelection()` branch and
navigated the browser to a search result. No arrow key needed to get there.
Arrow keys compounded it: they are how a user walks the IME candidate list, and
the component consumed them to move its own selection underneath.

**`pagefind-input`** — Escape cleared the entire query. During a composition
Escape is the key that cancels the conversion, so a user reverting one kana
lost everything they had typed.

**`pagefind-modal`** — the same Escape dismissed the whole modal.

## The change

Adds `core/composition.ts`, exporting `trackComposition(element)`, which returns
a predicate reporting whether a keydown belongs to a composition. Each of the
three keydown handlers returns early when it does.

`KeyboardEvent.isComposing` is the primary signal, with `compositionstart` /
`compositionend` tracked alongside it for two cases it does not cover on its own:

- WebKit fires `compositionend` *before* the keydown that ended the composition,
  so `isComposing` is already `false` on the Enter that commits a conversion. A
  keydown arriving within 50 ms of `compositionend` is therefore still treated as
  part of it, and that window is closed on the next keyup — Chromium and Gecko
  order the same three events keydown → compositionend → keyup, so their window
  shuts before the user's next keystroke.
- Some engines leave `isComposing` unset on a key that is part of a composition.
  `compositionstart` / `compositionend` covers those without reaching for the
  deprecated `keyCode === 229` test.

`focusout` clears the flag, since a composition abandoned by leaving the field
never gets its `compositionend` and a stuck flag would swallow keys indefinitely.

In `pagefind-modal` the existing `preventDefault()` / `stopPropagation()` still
run before the early return, so the dialog's own close-watcher does not fire and
the modal genuinely stays open.

## Verification

Two toolproof tests are included, covering both directions — keys ignored during
composition, and ordinary keyboard behaviour unchanged once it ends.

I could not run the integration suite locally (it needs the Rust toolchain), so
CI is the first full run of these. What I did verify, by building
`pagefind_ui/component` and serving the vendored bundle against a real Pagefind
index:

Driving Chromium's own composition pipeline over CDP, so `isComposing` is
computed by the browser rather than set by hand:

```js
await cdp.send('Input.imeSetComposition', { text: 'astro', selectionStart: 5, selectionEnd: 5 });
await cdp.send('Input.dispatchKeyEvent', { type: 'rawKeyDown', windowsVirtualKeyCode: 13, key: 'Enter', code: 'Enter' });
```

| bundle | mid-composition state | committing Enter |
|---|---|---|
| released 1.5.2 | `{ isOpen: true, activeIndex: 0, results: 17 }` | **navigated to a result** |
| this branch | `{ isOpen: true, activeIndex: 0, results: 17 }` | stayed put |

Identical state, so the only difference is the navigation. Also confirmed on
this branch:

- composing ArrowDown leaves `activeOptionOffset` unchanged; after the
  composition commits, ArrowDown moves it again and Enter navigates normally
- an Enter dispatched right after `compositionend` with `isComposing: false`
  (the WebKit ordering) is still ignored
- composing Escape in the modal leaves `dialog.open === true` and the query
  intact; a plain Escape afterwards still closes it

Separately, a guard of this shape has been running on a live trilingual site,
checked against hand-typed Japanese in both Chrome and Safari.

Happy to adjust the approach, split the `pagefind-input` / `pagefind-modal`
changes into their own PR, or drop the shared helper in favour of inlining the
check, whichever you prefer.
